### PR TITLE
Update group.js so that a spawn trigger isn't automaticly created by default when calling move()

### DIFF
--- a/types/group.js
+++ b/types/group.js
@@ -59,7 +59,7 @@ class $group {
      * @param {boolean} multiply Whether to fit the amount of units moved into GD units (multiplying by 3 does this)
      * @param {boolean} delay_trig Whether to do wait(duration)
      */
-    move(x, y, duration = 0, easing = NONE, easing_rate = 2, x_multiplier = 1, y_multiplier = 1, multiply = true, delay_trig = true) {
+    move(x, y, duration = 0, easing = NONE, easing_rate = 2, x_multiplier = 1, y_multiplier = 1, multiply = true, delay_trig = false) {
         $.add(object({
             OBJ_ID: 901,
             TARGET: this,


### PR DESCRIPTION
When you call group.move() with a duration, the delay trigger is set to true by default. Therefore it automatically creates a spawn trigger because it calls wait() by default. If you have only one object its gonna create multiple objects when it doesn't have to. So I set spawn delay to false by default.