### PR TITLE
collision() and collision_exit() with P1 and P2

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -48,9 +48,11 @@ let touch_end = (dual_side = false) => {
  * Listens to when two collision blocks collide
  * @param {block} block_a First block to listen to
  * @param {block} block_b Second block to listen to
+ * @param {boolean} P1 Player 1 as block a
+ * @param {boolean} P2 Player 2 as block a
  * @returns {event}
  */
-let collision = (a, b) => {
+let collision = (a, b, P1 = false, P2 = false) => {
     return {
         event: (t) =>
             $.add(object({
@@ -60,6 +62,8 @@ let collision = (a, b) => {
                 ACTIVATE_GROUP: true,
                 ACTIVATE_ON_EXIT: false,
                 TARGET: t,
+                PLAYER_1: P1,
+                PLAYER_2: P2,
             })),
     };
 };
@@ -68,9 +72,11 @@ let collision = (a, b) => {
  * Listens to when two collision blocks stop colliding
  * @param {block} block_a First block to listen to
  * @param {block} block_b Second block to listen to
+ * @param {boolean} P1 Player 1 as block a
+ * @param {boolean} P2 Player 2 as block a
  * @returns {event}
  */
-let collision_exit = (a, b) => {
+let collision_exit = (a, b, P1 = false, P2 = false) => {
     return {
         event: (t) =>
             $.add(object({
@@ -80,6 +86,8 @@ let collision_exit = (a, b) => {
                 ACTIVATE_GROUP: true,
                 ACTIVATE_ON_EXIT: true,
                 TARGET: t,
+                PLAYER_1: P1,
+                PLAYER_2: P2,
             })),
     };
 };

--- a/types/group.js
+++ b/types/group.js
@@ -59,7 +59,7 @@ class $group {
      * @param {boolean} multiply Whether to fit the amount of units moved into GD units (multiplying by 3 does this)
      * @param {boolean} delay_trig Whether to do wait(duration)
      */
-    move(x, y, duration = 0, easing = NONE, easing_rate = 2, x_multiplier = 1, y_multiplier = 1, multiply = true, delay_trig = false) {
+    move(x, y, duration = 0, easing = NONE, easing_rate = 2, x_multiplier = 1, y_multiplier = 1, multiply = true, delay_trig = true) {
         $.add(object({
             OBJ_ID: 901,
             TARGET: this,

--- a/types/group.js
+++ b/types/group.js
@@ -59,7 +59,7 @@ class $group {
      * @param {boolean} multiply Whether to fit the amount of units moved into GD units (multiplying by 3 does this)
      * @param {boolean} delay_trig Whether to do wait(duration)
      */
-    move(x, y, duration = 0, easing = NONE, easing_rate = 2, x_multiplier = 1, y_multiplier = 1, multiply = true, delay_trig = true) {
+    move(x, y, duration = 0, easing = NONE, easing_rate = 2, x_multiplier = 1, y_multiplier = 1, multiply = true, delay_trig = false) {
         $.add(object({
             OBJ_ID: 901,
             TARGET: this,


### PR DESCRIPTION
This adds P1 and P2 support to collision() and collision_exit(). I also updated the comment above the function.